### PR TITLE
feat!: pass baseUrl to streamResolver and dimension functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ async function streamResolver({ id, baseUrl }, callback) {
 }
 ```
 
-### Dimension Callback
+### Dimension Function
 
 The calling function can also supply the processor with an optional Dimension
 callback that takes information about the request [(`id` and `baseUrl`)](#id--baseurl) and returns a
@@ -77,7 +77,7 @@ callback that takes information about the request [(`id` and `baseUrl`)](#id--ba
 This allows for caching dimensions and avoiding an expensive image request.
 
 ```javascript
-async function dimensionResolver({ id, baseUrl }) {
+async function dimensionFunction({ id, baseUrl }) {
   let dimensions = lookDimensionsUpInDatabase(id);
   return { width: dimensions.width, height: dimensions.height };
 }
@@ -90,7 +90,7 @@ async function dimensionResolver({ id, baseUrl }) {
 const IIIF = require('iiif-processor');
 
 let url = 'http://iiif.example.com/iiif/2/abcdefgh/full/400,/0/default.jpg'
-let processor = new IIIF.Processor(url, streamResolver, { dimensionFunction: dimensionResolver });
+let processor = new IIIF.Processor(url, streamResolver, { dimensionFunction });
 processor.execute()
   .then(result => handleResult(result))
   .catch(err => handleError(err));
@@ -101,7 +101,7 @@ processor.execute()
 const IIIF = require('iiif-processor');
 
 let url = 'http://iiif.example.com/iiif/2/abcdefgh/full/400,/0/default.jpg'
-let processor = new IIIF.Processor(url, streamResolver, { dimensionFunction: dimensionResolver });
+let processor = new IIIF.Processor(url, streamResolver, { dimensionFunction });
 try {
   let result = await processor.execute();
   return result;
@@ -112,7 +112,7 @@ try {
 
 ### `id` / `baseUrl`
 
-The [stream resolver](#stream-resolver) and [dimensions callback](#dimension-callback) functions both accept an object with
+The [stream resolver](#stream-resolver) and [dimensions function](#dimension-function) functions both accept an object with
 `id` and `baseUrl` specified.
 
 For instance, for the request:
@@ -125,7 +125,7 @@ The `id` parameter is `42562145-0998-4b67-bab0-6028328f8319.png` and the `baseUr
 
 #### v1 -> v2
 
-* The `id` parameter passed to the [stream resolver](#stream-resolver) and [dimensions callback](#dimension-callback) was
+* The `id` parameter passed to the [stream resolver](#stream-resolver) and [dimensions callback](#dimension-function) was
   changed from a `string` to an `object` containing the `id` and `baseUrl`.
 
   To maintain the existing behavior, you can use destructuring of the argument. For example:
@@ -136,8 +136,8 @@ The `id` parameter is `42562145-0998-4b67-bab0-6028328f8319.png` and the `baseUr
   streamResolver({ id }) { }           // new
   streamResolver({ id }, callback) { } // new
 
-  dimensionResolver(id) { }            // old
-  dimensionResolver({ id }) { }        // new
+  dimensionFunction(id) { }            // old
+  dimensionFunction({ id }) { }        // new
   ```
 
   See [issue #19](https://github.com/samvera-labs/node-iiif/issues/19) for context on why this change was made.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ const IIIF = require('iiif-processor');
 const processor = new IIIF.Processor(url, streamResolver, opts);
 ```
 
-* `streamResolver` (function, required) – a callback function that returns a readable image stream for a given ID (see below)
+* `streamResolver` (function, required) – a callback function that returns a readable image stream for a given request (see below)
 * `opts`:
-  * `dimensionFunction` (function) – a callback function that returns the image dimensions for a given ID (see below)
+  * `dimensionFunction` (function) – a callback function that returns the image dimensions for a given request (see below)
   * `maxWidth` (integer) – the maximum width of an image that can be returned
   * `includeMetadata` (boolean) – if `true`, all metadata from the source image will be copied to the result
   * `density` (integer) – the pixel density to be included in the result image in pixels per inch
@@ -34,11 +34,13 @@ const processor = new IIIF.Processor(url, streamResolver, opts);
 ### Stream Resolver
 
 The calling function must supply the processor with a Stream Resolver callback
-function, which takes an ID and returns an open [Readable Stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) from which the source image can be read.
+function, which takes information about the request [(`id` and `baseUrl`)](#id--baseurl) and returns an open
+[Readable Stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) from which the source image can be read.
 
 #### Pairtree File Source
+
 ```javascript
-function streamResolver(id) {
+function streamResolver({ id, baseUrl }) {
   let imagePath = '/path/to/image/root/' + id.match(/.{1,2}/g).join('/') + '/image.tif';
   return fs.createReadStream(imagePath);
 }
@@ -49,10 +51,11 @@ case it should return the value of applying the callback to the stream. This all
 the function to do its own cleanup.
 
 #### Amazon S3 Bucket Source
+
 ```javascript
 const AWS = require('aws-sdk');
 
-async function streamResolver(id, callback) {
+async function streamResolver({ id, baseUrl }, callback) {
   let s3 = new AWS.S3();
   let key = id + '.tif';
   let request = s3.getObject({ Bucket: 'my-tiff-bucket', Key: key });
@@ -69,11 +72,12 @@ async function streamResolver(id, callback) {
 ### Dimension Callback
 
 The calling function can also supply the processor with an optional Dimension
-callback that takes an ID and returns a `{width: w, height: h}` object. This
-allows for caching dimensions and avoiding an expensive image request.
+callback that takes information about the request [(`id` and `baseUrl`)](#id--baseurl) and returns a
+`{width: w, height: h}` object.
+This allows for caching dimensions and avoiding an expensive image request.
 
 ```javascript
-async function dimensionResolver(id, callback) {
+async function dimensionResolver({ id, baseUrl }) {
   let dimensions = lookDimensionsUpInDatabase(id);
   return { width: dimensions.width, height: dimensions.height };
 }
@@ -105,6 +109,38 @@ try {
   handleError(err);
 }
 ```
+
+### `id` / `baseUrl`
+
+The [stream resolver](#stream-resolver) and [dimensions callback](#dimension-callback) functions both accept an object with
+`id` and `baseUrl` specified.
+
+For instance, for the request:
+
+> https://example.org/iiif/assets/42562145-0998-4b67-bab0-6028328f8319.png/10,20,30,40/pct:50/45/default.png
+
+The `id` parameter is `42562145-0998-4b67-bab0-6028328f8319.png` and the `baseUrl` is `https://example.org/iiif/assets`.
+
+### Breaking Changes
+
+#### v1 -> v2
+
+* The `id` parameter passed to the [stream resolver](#stream-resolver) and [dimensions callback](#dimension-callback) was
+  changed from a `string` to an `object` containing the `id` and `baseUrl`.
+
+  To maintain the existing behavior, you can use destructuring of the argument. For example:
+
+  ```js
+  streamResolver(id) { }               // old
+  streamResolver(id, callback) { }     // old
+  streamResolver({ id }) { }           // new
+  streamResolver({ id }, callback) { } // new
+
+  dimensionResolver(id) { }            // old
+  dimensionResolver({ id }) { }        // new
+  ```
+
+  See [issue #19](https://github.com/samvera-labs/node-iiif/issues/19) for context on why this change was made.
 
 ### Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-processor",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "IIIF 2.1 Image API modules for NodeJS",
   "main": "index.js",
   "repository": "https://github.com/samvera-labs/node-iiif",

--- a/tests/processor.test.js
+++ b/tests/processor.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { Stream } = require('stream');
 const iiif = require('../index');
 
 let subject;
@@ -158,3 +159,46 @@ describe('constructor errors', () => {
     }, iiif.IIIFError);
   });
 });
+
+describe('stream processor', () => {
+  it('passes the id and baseUrl to the function', () => {
+    expect.assertions(2) // ensures our streamResolver assertions are both executed in this test
+
+    const streamResolver = ({ id, baseUrl }) => {
+      expect(id).toEqual('i');
+      expect(baseUrl).toEqual('https://example.org/iiif/2/ab/cd/ef/gh');
+
+      return new Stream.Readable({
+        read() {}
+      });
+    }
+
+    const subject = new iiif.Processor(`https://example.org/iiif/2/ab/cd/ef/gh/i/10,20,30,40/pct:50/45/default.png`, streamResolver);
+    subject.execute();
+  })
+})
+
+describe('dimension function', () => {
+  it('passes the id and baseUrl to the function', () => {
+    expect.assertions(2) // ensures our dimension function assertions are both executed in this test
+
+    const streamResolver = ({ id, baseUrl }) => {
+      return new Stream.Readable({
+        read() {}
+      });
+    }
+
+    const dimensionFunction = ({ id, baseUrl }) => {
+      expect(id).toEqual('i');
+      expect(baseUrl).toEqual('https://example.org/iiif/2/ab/cd/ef/gh');
+      return { w: 100, h: 100 }
+    }
+
+    const subject = new iiif.Processor(
+      `https://example.org/iiif/2/ab/cd/ef/gh/i/10,20,30,40/pct:50/45/default.png`,
+      streamResolver,
+      { dimensionFunction }
+    );
+    subject.execute();
+  })
+})

--- a/tests/processor.test.js
+++ b/tests/processor.test.js
@@ -9,7 +9,7 @@ const dims = { width: 1024, height: 768 };
 
 describe('IIIF Processor', () => {
   beforeEach(() => {
-    subject = new iiif.Processor(`${base}/10,20,30,40/pct:50/45/default.png`, (id) => id);
+    subject = new iiif.Processor(`${base}/10,20,30,40/pct:50/45/default.png`, ({ id }) => id);
   });
 
   it('Parse URL', () => {
@@ -40,7 +40,7 @@ describe('Include metadata', () => {
   beforeEach(() => {
     subject = new iiif.Processor(
       `${base}/10,20,30,40/pct:50/45/default.jpg`,
-      (id) => id,
+      ({ id }) => id,
       { includeMetadata: true }
     );
   });
@@ -55,7 +55,7 @@ describe('Include metadata', () => {
 
 describe('TIFF Download', () => {
   beforeEach(() => {
-    subject = new iiif.Processor(`${base}/10,20,30,40/pct:50/45/default.tif`, (id) => id);
+    subject = new iiif.Processor(`${base}/10,20,30,40/pct:50/45/default.tif`, ({ id }) => id);
   });
 
   it('Output TIFF format', () => {
@@ -78,7 +78,7 @@ describe('Density', () => {
     subject = (ext) => {
       return new iiif.Processor(
         `https://example.org/iiif/2/ab/cd/ef/gh/i/10,20,30,40/pct:50/45/default.${ext}`,
-        (id) => id,
+        ({ id }) => id,
         { density: 600 }
       );
     };
@@ -114,7 +114,7 @@ describe('constructor', () => {
   it('must parse the object-based constructor', () => {
     subject = new iiif.Processor(
       `${base}/10,20,30,40/pct:50/45/default.tif`,
-      () => 'streamResolver', 
+      () => 'streamResolver',
       { dimensionFunction: () => 'dimensionFunction', maxWidth: 'maxWidth', includeMetadata: true, density: 600 }
     );
 
@@ -154,7 +154,7 @@ describe('constructor errors', () => {
 
   it('requires a valid URL', () => {
     assert.throws(() => {
-      return new iiif.Processor(`${base}/10,20,30,40/pct:50/45/default.blargh`, (id) => id);
+      return new iiif.Processor(`${base}/10,20,30,40/pct:50/45/default.blargh`, ({ id }) => id);
     }, iiif.IIIFError);
   });
 });


### PR DESCRIPTION
This PR is in response to issue #19. It reworks the `id` parameter for `streamResolver` and `dimensionsFunction` to accept both the `id` and the `baseUrl`.

BREAKING CHANGE: the function signature for streamResolver and dimension functions has changed. See README.md for more details.

Fixes #19 