### PR TITLE
fix: improve .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
 node_modules
+.eslintignore
 .eslintrc
 .vscode
 .codeclimate.yml
 .circleci
+tests/
+scripts/


### PR DESCRIPTION
Currently, these are the files included in the published package:

```
> npm pack
npm notice
npm notice 📦  iiif-processor@1.0.0
npm notice === Tarball Contents ===
npm notice 18B    .eslintignore
npm notice 9.9kB  CONTRIBUTING.md
npm notice 11.6kB LICENSE
npm notice 4.7kB  README.md
npm notice 5.5kB  index.js
npm notice 62B    lib/error.js
npm notice 5.4kB  lib/transform.js
npm notice 1.3kB  package.json
npm notice 265B   scripts/test.js
npm notice 314B   tests/fixtures/iiif-values.js
npm notice 1.6MB  tests/fixtures/samvera.tif
npm notice 3.5kB  tests/integration.test.js
npm notice 4.9kB  tests/processor.test.js
npm notice 2.3kB  tests/transform.test.js
npm notice === Tarball Details ===
npm notice name:          iiif-processor
npm notice version:       1.0.0
npm notice filename:      iiif-processor-1.0.0.tgz
npm notice package size:  72.3 kB
npm notice unpacked size: 1.7 MB
npm notice shasum:        fdacde6de4709bf7c98c478a444f7bd61bf1972b
npm notice integrity:     sha512-NyKZgAwWx/U7I[...]F3gn+JFMppZ3g==
npm notice total files:   14
npm notice
iiif-processor-1.0.0.tgz
```

With these changes, this is the resulting package:
```
> npm pack
npm notice
npm notice 📦  iiif-processor@1.0.0
npm notice === Tarball Contents ===
npm notice 9.9kB  CONTRIBUTING.md
npm notice 11.6kB LICENSE
npm notice 4.7kB  README.md
npm notice 5.5kB  index.js
npm notice 62B    lib/error.js
npm notice 5.4kB  lib/transform.js
npm notice 1.3kB  package.json
npm notice === Tarball Details ===
npm notice name:          iiif-processor
npm notice version:       1.0.0
npm notice filename:      iiif-processor-1.0.0.tgz
npm notice package size:  13.7 kB
npm notice unpacked size: 38.4 kB
npm notice shasum:        3ac672df8f7a647a1190843a073487b6e11b6a35
npm notice integrity:     sha512-6E0UAY6ev+Cit[...]AwcSb8htFfjfg==
npm notice total files:   7
npm notice
iiif-processor-1.0.0.tgz
```

The main benefit is removing the testing image, which is > 1 MB.