### PR TITLE
Get rid of most explicit any casts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
       "extends": ["plugin:@typescript-eslint/recommended"],
       "rules": {
         "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-        "@typescript-eslint/no-explicit-any": "off"
+        "@typescript-eslint/no-explicit-any": "warn"
       }
     }
   ]

--- a/src/calculator/v3.ts
+++ b/src/calculator/v3.ts
@@ -1,8 +1,9 @@
-import { Base } from './base';
+import { CalculatorOptions } from '../contracts';
+import { Base, ValidatorMap } from './base';
 
 export class Calculator extends Base {
-  static _matchers () {
-    const result: any = { ...(super._matchers() as any) };
+  static _matchers (): ValidatorMap {
+    const result: ValidatorMap = { ...super._matchers() };
     result.size = [...result.size].reduce((sizes: string[], pattern: string) => {
       if (pattern !== 'full') sizes.push(`\\^?${pattern}`);
       return sizes;
@@ -10,15 +11,15 @@ export class Calculator extends Base {
     return result;
   }
 
-  constructor (dims: { width: number; height: number }, opts: any = {}) {
+  constructor (dims: { width: number; height: number }, opts: CalculatorOptions = {}) {
     super(dims, opts);
-    (this as any)._canonicalInfo.size = 'max';
-    (this as any)._parsedInfo.upscale = false;
+    this._canonicalInfo.size = 'max';
+    this._parsedInfo.upscale = false;
   }
 
   size (v: string) {
     if (v[0] === '^') {
-      (this as any)._parsedInfo.upscale = true;
+      this._parsedInfo.upscale = true;
       v = v.slice(1, v.length);
     }
     return super.size(v);

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,4 +1,4 @@
-import type { BoundingBox, Dimensions, Format, MaxDimensions, Quality } from './types';
+import type { BoundingBox, Dimensions, Format, IIIFSpec, MaxDimensions, Quality } from './types';
 
 export interface Calculated {
   region: BoundingBox;
@@ -19,9 +19,11 @@ export interface CalculatorLike {
   canonicalPath(): string;
 }
 
+export type CalculatorOptions = { max?: MaxDimensions };
+
 export type CalculatorCtor = {
-  new (dims: Dimensions, opts?: { max?: MaxDimensions }): CalculatorLike;
-  parsePath(path: string): any;
+  new (dims: Dimensions, opts?: CalculatorOptions): CalculatorLike;
+  parsePath(path: string): IIIFSpec | null;
 };
 
 export interface InfoDocInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,8 +9,20 @@ export type Dimensions = {
   width: number;
   height: number;
 };
+export type ResolvedDimensions = Dimensions | Dimensions[];
 
 export type Format = 'jpg' | 'jpeg' | 'tif' | 'tiff' | 'png' | 'webp';
+
+export type IIIFSpec = {
+  id: string;
+  info?: boolean;
+  region?: string;
+  size?: string;
+  rotation?: string;
+  quality?: string;
+  format?: string;
+  density?: number;
+};
 
 export type MaxDimensions = {
   width?: number;

--- a/src/v2/info.ts
+++ b/src/v2/info.ts
@@ -1,3 +1,4 @@
+import { Dimensions } from '../types';
 import { Formats, Qualities } from '../calculator/v2';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Debug from 'debug';
@@ -36,7 +37,7 @@ export function infoDoc ({ id, width, height, sizes, max }: InfoDocInput): InfoD
     maxWidth: max?.width,
     maxHeight: max?.height,
     maxArea: max?.area
-  } as any;
+  };
 
   return {
     '@context': 'http://iiif.io/api/image/2/context.json',
@@ -46,7 +47,7 @@ export function infoDoc ({ id, width, height, sizes, max }: InfoDocInput): InfoD
     height,
     sizes,
     tiles: [
-      { width: 512, height: 512, scaleFactors: sizes.map((_v: any, i: number) => 2 ** i) }
+      { width: 512, height: 512, scaleFactors: sizes.map((_v: Dimensions, i: number) => 2 ** i) }
     ],
     profile: [profileLink, { ...IIIFProfile, ...maxAttrs }]
   };

--- a/src/v3/info.ts
+++ b/src/v3/info.ts
@@ -1,3 +1,4 @@
+import { Dimensions } from '../types';
 import { Formats, Qualities } from '../calculator/v3';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Debug from 'debug';
@@ -13,8 +14,16 @@ const ComplianceProfile = {
 };
 
 const IIIFExtras = {
-  extraFormats: new Set(Formats.filter((format) => !(ComplianceProfile.formats as Set<string>).has(format))),
-  extraQualities: new Set(Qualities.filter((quality) => !(ComplianceProfile.qualities as Set<string>).has(quality))),
+  extraFormats: new Set(
+    Formats.filter(
+      (format) => !(ComplianceProfile.formats as Set<string>).has(format)
+    )
+  ),
+  extraQualities: new Set(
+    Qualities.filter(
+      (quality) => !(ComplianceProfile.qualities as Set<string>).has(quality)
+    )
+  ),
   extraFeatures: [
     'canonicalLinkHeader',
     'mirroring',
@@ -32,7 +41,7 @@ export function infoDoc ({ id, width, height, sizes, max }: InfoDocInput): InfoD
     maxWidth: max?.width,
     maxHeight: max?.height,
     maxArea: max?.area
-  } as any;
+  };
 
   return {
     '@context': 'http://iiif.io/api/image/3/context.json',
@@ -46,7 +55,11 @@ export function infoDoc ({ id, width, height, sizes, max }: InfoDocInput): InfoD
     extraQualities: [...(IIIFExtras.extraQualities as Set<string>)],
     extraFeatures: IIIFExtras.extraFeatures,
     tiles: [
-      { width: 512, height: 512, scaleFactors: sizes.map((_v: any, i: number) => 2 ** i) }
+      {
+        width: 512,
+        height: 512,
+        scaleFactors: sizes.map((_v: Dimensions, i: number) => 2 ** i)
+      }
     ],
     profile: ComplianceProfile,
     ...maxAttrs


### PR DESCRIPTION
This PR gets rid of almost all of the remaining casts to `any`, mostly by deleting them and leaving some internals untyped, but also by creating some new explicit types and leveraging some types from `sharp`. There are two `any`s still in play, with explicit instructions for the linter to ignore them, and a _little_ abuse of `unknown`.